### PR TITLE
Extract activerecord db connection for hyperion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', github: 'rails/rails'
 gem 'pg', :platform => :ruby
+gem 'hyperion-postgres'
 gem 'activerecord-jdbcpostgresql-adapter', :platform => :jruby
 gem 'puma'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,8 @@ GEM
     data_objects (0.10.10)
       addressable (~> 2.1)
     diff-lcs (1.2.1)
+    do_postgres (0.10.10)
+      data_objects (= 0.10.10)
     do_sqlite3 (0.10.10)
       data_objects (= 0.10.10)
     erubis (2.7.0)
@@ -115,6 +117,9 @@ GEM
     hike (1.2.1)
     hyperion-api (0.2.0)
       uuidtools (= 2.1.3)
+    hyperion-postgres (0.2.0)
+      do_postgres (= 0.10.10)
+      hyperion-sql (= 0.2.0)
     hyperion-sql (0.2.0)
       hyperion-api (= 0.2.0)
     hyperion-sqlite (0.2.0)
@@ -212,6 +217,7 @@ DEPENDENCIES
   capybara
   coffee-rails!
   haml!
+  hyperion-postgres
   jquery-rails
   newrelic_rpm
   pg

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:
-#require "active_record/railtie"
+require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "sprockets/railtie"

--- a/config/initializers/afterburner.rb
+++ b/config/initializers/afterburner.rb
@@ -1,0 +1,4 @@
+require_relative '../../lib/hyperion_configuration_extractor'
+connection_string = HyperionConfigurationExtractor.new(ActiveRecord::Base).connection_string
+Abc::Adapters.datastore_options = [:postgres, connection_url: connection_string]
+Abc::Adapters.enable_datastore!

--- a/lib/hyperion_configuration_extractor.rb
+++ b/lib/hyperion_configuration_extractor.rb
@@ -1,0 +1,35 @@
+class HyperionConfigurationExtractor
+  class DatabaseNotSpecifiedError < StandardError; end
+
+  def initialize(base)
+    @base = base
+  end
+
+  def connection_string
+    "postgres://#{username}:#{password}@#{host}/#{database}"
+  end
+
+  def host
+    config[:host] || 'localhost'
+  end
+
+  def database
+    config[:database] || raise(DatabaseNotSpecifiedError)
+  end
+
+  def username
+    config[:username]
+  end
+
+  def password
+    config[:password]
+  end
+
+  private
+  attr_reader :base
+
+  def config
+    base.connection_config
+  end
+end
+

--- a/spec/models/hyperion_configuration_extractor_spec.rb
+++ b/spec/models/hyperion_configuration_extractor_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require_relative '../../lib/hyperion_configuration_extractor'
+
+describe HyperionConfigurationExtractor do
+  describe "extracting postgres connection strings from ActiveRecord::Base" do
+    let(:config){ {} }
+    let(:base){ mock }
+    subject{ HyperionConfigurationExtractor.new(base) }
+
+    before do
+      base.stub(:connection_config).and_return(config)
+    end
+
+    it "outputs the connection string appropriately" do
+      config[:database] = "foo"
+      config[:username] = "bar"
+      config[:password] = "baz"
+      subject.connection_string.should == "postgres://bar:baz@localhost/foo"
+    end
+
+    describe "getting the hostname" do
+      it "gets the config host when it's available" do
+        config[:host] = 'foo'
+        subject.host.should == "foo"
+      end
+
+      it "defaults to 'localhost' if no host is specified" do
+        subject.host.should == 'localhost'
+      end
+    end
+
+    describe "getting the database" do
+      it "gets the config database" do
+        config[:database] = 'foo'
+        subject.database.should == "foo"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will successfully configure non-socket postgres database
connections from activerecord config/database.yml.  It's naive but it
can be grown upon.  Expect this to ultimately be extracted into
afterburnercms-rails
